### PR TITLE
use pre defined default user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,8 +11,8 @@ ARG INSTALL_ZSH="true"
 ARG UPGRADE_PACKAGES="false"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-ARG USERNAME=vscode
-ARG USER_UID=1001
+ARG USERNAME=rstudio
+ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 COPY library-scripts/*.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,5 +49,5 @@
 	// "postCreateCommand": "pip3 install -r requirements.txt",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "rstudio"
 }


### PR DESCRIPTION
There is no need to use different users for VSCode and RStudio Server, I believe the same user can be used.

Note that the R definition included in the Remote-Containers extension already sets the user name to `rstudio` to be compatible with `rocker/rstudio`.
https://github.com/microsoft/vscode-dev-containers/blob/d98fef4fd8ae814c6056db8d936009fef97bed4b/containers/r/.devcontainer/Dockerfile#L13
